### PR TITLE
Option for JSON string output from device and dg list and info commands

### DIFF
--- a/bin/cmds/device/info.js
+++ b/bin/cmds/device/info.js
@@ -39,7 +39,8 @@ exports.describe = COMMAND_SHORT_DESCR;
 exports.builder = function (yargs) {
     const options = Options.getOptions({
         [Options.DEVICE_IDENTIFIER] : true,
-        [Options.DEBUG] : false
+        [Options.DEBUG] : false,
+        [Options.OUTPUT] : ""
     });
     return yargs
         .usage(Options.getUsage(COMMAND_SECTION, COMMAND, COMMAND_DESCRIPTION, Options.getCommandOptions(options)))

--- a/bin/cmds/device/list.js
+++ b/bin/cmds/device/list.js
@@ -62,7 +62,8 @@ exports.builder = function (yargs) {
         [Options.ASSIGNED] : false,
         [Options.ONLINE] : false,
         [Options.OFFLINE] : false,
-        [Options.DEBUG] : false
+        [Options.DEBUG] : false,
+        [Options.OUTPUT] : ""
     });
     return yargs
         .usage(Options.getUsage(COMMAND_SECTION, COMMAND, COMMAND_DESCRIPTION, Options.getCommandOptions(options)))

--- a/bin/cmds/dg/info.js
+++ b/bin/cmds/dg/info.js
@@ -43,7 +43,8 @@ exports.builder = function (yargs) {
             demandOption : false,
             describe : 'Displays additional information. Details about every Device assigned to the Device Group, Deployments and other.'
         },
-        [Options.DEBUG] : false
+        [Options.DEBUG] : false,
+        [Options.OUTPUT] : ""
     });
     return yargs
         .usage(Options.getUsage(COMMAND_SECTION, COMMAND, COMMAND_DESCRIPTION, Options.getCommandOptions(options)))

--- a/bin/cmds/dg/list.js
+++ b/bin/cmds/dg/list.js
@@ -50,7 +50,8 @@ exports.builder = function (yargs) {
             demandOption : false,
             describe : 'Lists Device Groups of the specified type only.',
         },
-        [Options.DEBUG] : false
+        [Options.DEBUG] : false,
+        [Options.OUTPUT] : ""
     });
     return yargs
         .usage(Options.getUsage(COMMAND_SECTION, COMMAND, COMMAND_DESCRIPTION, Options.getCommandOptions(options)))

--- a/bin/cmds/log/stream.js
+++ b/bin/cmds/log/stream.js
@@ -55,7 +55,8 @@ exports.builder = function (yargs) {
                 ' Project File in the current directory, all Devices assigned to the Device Group referenced by the Project File are assumed.',
                 Options.DEVICE_IDENTIFIER, Options.DEVICE_GROUP_IDENTIFIER, Options.DEVICE_IDENTIFIER, Options.DEVICE_GROUP_IDENTIFIER)
         },
-        [Options.DEBUG] : false
+        [Options.DEBUG] : false,
+        [Options.OUTPUT] : ""
     });
 
     return yargs

--- a/bin/cmds/loginkey/list.js
+++ b/bin/cmds/loginkey/list.js
@@ -38,7 +38,8 @@ exports.describe = COMMAND_SHORT_DESCR;
 
 exports.builder = function (yargs) {
     const options = Options.getOptions({
-        [Options.DEBUG] : false
+        [Options.DEBUG] : false,
+        [Options.OUTPUT] : ""
     });
     return yargs
         .usage(Options.getUsage(COMMAND_SECTION, COMMAND, COMMAND_DESCRIPTION, Options.getCommandOptions(options)))

--- a/lib/Device.js
+++ b/lib/Device.js
@@ -178,6 +178,9 @@ class Device extends Entity {
                 filters.push(new ListHelper.ArtificialFilter((entity) => Promise.resolve(!entity.attributes.device_online)));
             }
         }
+        if (options._options.output == "JSON"){
+            UserInteractor.PRINT_FORMAT = UserInteractor.PRINT_FORMAT_JSON
+        }
 
         return super._listEntities(filters);
     }

--- a/lib/DeviceGroup.js
+++ b/lib/DeviceGroup.js
@@ -330,7 +330,10 @@ class DeviceGroup extends Entity {
         if (options.deviceGroupType) {
             filters.push(new ListHelper.DeviceGroupTypeFilter(DeviceGroups.FILTER_TYPE, options.deviceGroupType));
         }
-        return super._listEntities(filters);
+        if (options._options.output == "JSON"){
+            UserInteractor.PRINT_FORMAT = UserInteractor.PRINT_FORMAT_JSON
+        }
+        return super._listEntities(filters, options);
     }
 
     // Reboots all of the Devices associated with the Device Group.
@@ -606,6 +609,9 @@ class DeviceGroup extends Entity {
         else if (this._projectConfig.exists()) {
             return this._projectConfig.checkConfig().then(() =>
                 this._identifier.initByIdFromConfig(this._projectConfig.deviceGroupId, this._projectConfig.type));
+        }
+        else if(options.output){
+            UserInteractor.PRINT_FORMAT = UserInteractor.PRINT_FORMAT_JSON
         }
         return Promise.resolve();
     }

--- a/lib/Log.js
+++ b/lib/Log.js
@@ -43,6 +43,9 @@ class Log {
         if (options.debug) {
             this._helper.debug = true;
         }
+        if (options != {} && options._options.output == "JSON"){
+            UserInteractor.PRINT_FORMAT = UserInteractor.PRINT_FORMAT_JSON
+        }
         this._projectConfig = ProjectConfig.getEntity();
         this._devices = [];
         this._deviceIds = [];

--- a/lib/util/Entity.js
+++ b/lib/util/Entity.js
@@ -182,6 +182,9 @@ class Entity {
     //
     // Returns:                 Nothing
     info(options) {
+        if (options._options.output == "JSON"){
+            UserInteractor.PRINT_FORMAT = UserInteractor.PRINT_FORMAT_JSON
+        }
         this.getEntity(true).
             then(() => this._displayInfo(options)).
             then(() => UserInteractor.printSuccessStatus()).

--- a/lib/util/Options.js
+++ b/lib/util/Options.js
@@ -616,6 +616,15 @@ class Options {
                 default: undefined,
                 _usage: ''
             },
+            [Options.OUTPUT] : {
+                describe: 'Output in JSON string, spinner disabled, and print message removed.',
+                alias: 's',
+                nargs: 1,
+                type : 'string',
+                noValue: true,
+                default: undefined,
+                _usage: ''
+            },
             [Options.PRODUCT_IDENTIFIER] : {
                 describe: 'Product Identifier: Product Id or Product name.' +
                     ' If not specified, the Product referenced by Project File in the current directory is assumed' +
@@ -1244,6 +1253,14 @@ class Options {
 
     get preFactory() {
         return this._options[Options.PRE_FACTORY];
+    }
+
+    static get OUTPUT() {
+        return 'output';
+    }
+
+    get output() {
+        return this._options[Options.OUTPUT];
     }
 
     static get PRODUCT() {

--- a/lib/util/Options.js
+++ b/lib/util/Options.js
@@ -617,7 +617,7 @@ class Options {
                 _usage: ''
             },
             [Options.OUTPUT] : {
-                describe: 'Output in JSON string, spinner disabled, and print message removed.',
+                describe: 'Output in pure JSON string, Contacting Imp Central spinner disabled, and extraneous messages removed.',
                 alias: 's',
                 nargs: 1,
                 type : 'string',

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -159,8 +159,32 @@ const ERRORS = {
     UNEXPECTED_STATE : 'Unexpected state'
 };
 
+const PRINT_FORMAT_PRETTY = 'PRINT_FORMAT_PRETTY';
+const PRINT_FORMAT_JSON = 'PRINT_FORMAT_JSON';
+
+let _PRINT_FORMAT = PRINT_FORMAT_PRETTY
+
 // Helper class for interactions with a user.
 class UserInteractor {
+    static get PRINT_FORMAT() {
+        return _PRINT_FORMAT
+    }
+
+    static set PRINT_FORMAT(printFormat) {
+        if(printFormat != PRINT_FORMAT_PRETTY && printFormat != PRINT_FORMAT_JSON){
+            throw(`ERROR in set UserInteractor.PRINT_FORMAT.  printFormat=${printFormat} and is not one of [UserInteractor.PRINT_FORMAT_PRETTY, UserInteractor.PRINT_FORMAT_JSON]`)
+        }
+        _PRINT_FORMAT = printFormat
+    }
+
+    static get PRINT_FORMAT_PRETTY() {
+        return PRINT_FORMAT_PRETTY;
+    }
+
+    static get PRINT_FORMAT_JSON() {
+        return PRINT_FORMAT_JSON;
+    }
+
     static get MESSAGES() {
         return MESSAGES;
     }
@@ -190,7 +214,7 @@ class UserInteractor {
 
     static printMessage(message, ...args) {
         UserInteractor.spinnerStop();
-        if(!UserInteractor.dontPrint()){
+        if(UserInteractor.PRINT_FORMAT == PRINT_FORMAT_PRETTY){
             console.log(message, ...args);
         }
     }
@@ -242,11 +266,11 @@ class UserInteractor {
         if (!data || Array.isArray(data) && data.length === 0 || Object.keys(data).length === 0) {
             return;
         }
-        if(!UserInteractor.dontPrint()){
+        if(UserInteractor.PRINT_FORMAT == PRINT_FORMAT_PRETTY){
             const jsonFormatter = new JsonFormatter();
             console.log(jsonFormatter.render(data));
         }
-        else{
+        else { //if(UserInteractor.PRINT_FORMAT == PRINT_FORMAT_JSON){
             console.log(JSON.stringify(data,null,'\t'))
         }
     }
@@ -488,18 +512,9 @@ class UserInteractor {
         UserInteractor._enableSpinner = value;
     }
 
-    static dontPrint(){
-        var dontPrint = false
-       for (var i = 0; i < Object.keys(process.argv).length; i++){
-           if(process.argv[i] =="--output" && process.argv[i+1] == "JSON") dontPrint = true
-       }
-       return dontPrint
-    }
-
-    static spinnerStart() {
-
+        static spinnerStart() {
         if (UserInteractor._enableSpinner && !UserInteractor.spinner.isSpinning()) {
-            if(!UserInteractor.dontPrint()){
+            if(UserInteractor.PRINT_FORMAT == PRINT_FORMAT_PRETTY){
                 UserInteractor.spinner.start();
             }
         }

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -190,7 +190,9 @@ class UserInteractor {
 
     static printMessage(message, ...args) {
         UserInteractor.spinnerStop();
-        console.log(message, ...args);
+        if(!UserInteractor.dontPrint()){
+            console.log(message, ...args);
+        }
     }
 
     static printMessageWithStatus(message, ...args) {
@@ -240,8 +242,13 @@ class UserInteractor {
         if (!data || Array.isArray(data) && data.length === 0 || Object.keys(data).length === 0) {
             return;
         }
-        const jsonFormatter = new JsonFormatter();
-        console.log(jsonFormatter.render(data));
+        if(!UserInteractor.dontPrint()){
+            const jsonFormatter = new JsonFormatter();
+            console.log(jsonFormatter.render(data));
+        }
+        else{
+            console.log(JSON.stringify(data,null,'\t'))
+        }
     }
 
     static processError(error) {
@@ -481,9 +488,20 @@ class UserInteractor {
         UserInteractor._enableSpinner = value;
     }
 
+    static dontPrint(){
+        var dontPrint = false
+       for (var i = 0; i < Object.keys(process.argv).length; i++){
+           if(process.argv[i] =="--output" && process.argv[i+1] == "JSON") dontPrint = true
+       }
+       return dontPrint
+    }
+
     static spinnerStart() {
+
         if (UserInteractor._enableSpinner && !UserInteractor.spinner.isSpinning()) {
-            UserInteractor.spinner.start();
+            if(!UserInteractor.dontPrint()){
+                UserInteractor.spinner.start();
+            }
         }
     }
 


### PR DESCRIPTION
```---output JSON``` option added to the ```dg list```, ```dg info```, ```device list```, ```device info```, and ```log stream``` commands. This option was added to enable programmatic command line tools to use the output from ```impt``` commands natively without doing any string parsing. I only modified the commands that I am currently using. It would be nice to make this an option for all commands.