### PR TITLE
VSCode compatible hyperlinks in terminal output for compilation errors

### DIFF
--- a/lib/Build.js
+++ b/lib/Build.js
@@ -139,7 +139,7 @@ class Build extends Entity {
     deploy(options) {
         this._deploy(options).
             then(() => UserInteractor.printSuccessStatus()).
-            catch(error => UserInteractor.processError(error));
+            catch(error => UserInteractor.processError(error, this._agentFileName, this._deviceFileName));
     }
 
     // Creates, deploys and run a build or reports an error occurred.
@@ -164,7 +164,9 @@ class Build extends Entity {
                     UserInteractor.printSuccessStatus();
                 }
             }).
-            catch(error => UserInteractor.processError(error));
+            catch(error => {
+				UserInteractor.processError(error, this._agentFileName, this._deviceFileName)
+			});
     }
 
     // Updates tags of the current Build.

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -260,7 +260,7 @@ class UserInteractor {
         console.log(jsonFormatter.render(data));
     }
 
-    static processError(error) {
+    static processError(error, agentFileName, deviceFileName) {
         UserInteractor.spinnerStop();
         if (UserInteractor.debug) {
             UserInteractor.printMessage(error);
@@ -341,7 +341,7 @@ class UserInteractor {
             UserInteractor.printErrorStatus();
         }
         else if (error instanceof ImpCentralApi.Errors.ImpCentralApiError) {
-            UserInteractor.printImpCentralApiError(error);
+            UserInteractor.printImpCentralApiError(error, agentFileName, deviceFileName);
             UserInteractor.printErrorStatus();
         }
         else if (error instanceof ImpCentralApi.Errors.InvalidDataError) {
@@ -359,9 +359,9 @@ class UserInteractor {
         }
     }
 
-    static printImpCentralApiError(error) {
+    static printImpCentralApiError(error, agentFileName, deviceFileName) {
         if (error.body && error.body.hasOwnProperty('errors')) {
-            UserInteractor._printErrorsAndWarnings(error.body.errors);
+            UserInteractor._printErrorsAndWarnings(error.body.errors, agentFileName, deviceFileName);
         }
         else {
             UserInteractor.printError(error.message);
@@ -374,10 +374,19 @@ class UserInteractor {
         }
     }
 
-    static _printErrorsAndWarnings(entities) {
+    static _printErrorsAndWarnings(entities, agentFileName, deviceFileName) {
         if (Array.isArray(entities)) {
+
             entities.forEach((entity) => {
                 if (['title', 'detail', 'status'].every(prop => entity.hasOwnProperty(prop))) {
+
+					if(entity.title === "Compilation Error"){
+						entity.meta.forEach((meta) => {
+							var file = meta.file === "agent_code" ? agentFileName : deviceFileName
+							UserInteractor.printMessage(file + ":" + meta.row + ":" + meta.column)
+						})
+					}
+
                     const message = entity.title + ': ' + entity.detail;
                     if (UserInteractor._isError(entity)) {
                         UserInteractor.printError(message);


### PR DESCRIPTION
@ppetrosh - this PR provides an update that allows for `impt build run` squirrel compilation errors to be clickable in VSCode via `<path>:<line>:<column>` syntax ala https://code.visualstudio.com/updates/v1_12#_integrated-terminal-link-line-and-column-ranges.  This makes the errors much more useful/productive as you don't have to go chase them down in code.

![screenshot 2018-07-12 09 20 02](https://user-images.githubusercontent.com/583660/42635717-cad3c0f4-85b4-11e8-8bf8-fddd9ebb35db.png)

This is just a simple proof of concept that should be extended properly - not being familiar with Yargs, this code base is a bit tough for me to navigate as far as development goes, but hopefully this gives you enough of an idea of what would need to happen to pull it in?

In a future state, this would actually link you to the builder source files in addition to the __built__ file - I'm hoping your much more familiar with the structure of the impt code base and thats something you could add!

