### PR TITLE
The impt test run execution has been modified to skip checking the device's online status.

### DIFF
--- a/lib/util/TestHelper.js
+++ b/lib/util/TestHelper.js
@@ -224,7 +224,7 @@ class TestHelper {
 
             // Display a warning message to the user to verify that the device is physically online
             if (!testIsAgentOnly ) {
-                UserInteractor.printInfo(c.yellow("Warning: please ensure imp device " + device.id + " is online,Current test will fail if the device under test is physically offline"));
+                UserInteractor.printInfo(c.yellow("Warning: please ensure imp device " + device.id + " is online. Current test will fail if the device under test is physically offline"));
             }
 
             // create agent/device code to run

--- a/lib/util/TestHelper.js
+++ b/lib/util/TestHelper.js
@@ -222,9 +222,9 @@ class TestHelper {
             this._info(Util.format(UserInteractor.MESSAGES.TEST_USE_DEVICE,
                 device.name ? device.name : '', device.id, deviceIndex, this._devices.length));
 
-            // check online state
-            if (!testIsAgentOnly && !device.online) {
-                throw new TestSession.Errors.DevicePowerstateError(UserInteractor.ERRORS.TEST_DEVICE_OFFLINE);
+            // Display a warning message to the user to verify that the device is physically online
+            if (!testIsAgentOnly ) {
+                UserInteractor.printInfo(c.yellow("Warning: please ensure imp device " + device.id + " is online,Current test will fail if the device under test is physically offline"));
             }
 
             // create agent/device code to run


### PR DESCRIPTION
The online/offline status received from the IC state microservice is not entirely reliable, as the connection may have been lost without the IC state microservice being aware of it. The code execution for impt test run has been modified to display a warning about the device status instead of throwing an error.